### PR TITLE
Map Square - Team View Stuff

### DIFF
--- a/PROShine/Views/MainWindow.xaml
+++ b/PROShine/Views/MainWindow.xaml
@@ -117,7 +117,7 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
-        
+
         <SolidColorBrush x:Key="CheckedBlueBorder" Color="#FF7289da" />
         <Style x:Key="SwitchStyle" TargetType="{x:Type CheckBox}">
             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
@@ -339,14 +339,20 @@
                     </ToolTip>
                 </CheckBox.ToolTip>
             </CheckBox>
+            <CheckBox x:Name="IsTrainerBattlesActiveSwitch" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="NPC-Battle: " Checked="IsTrainerBattlesActiveSwitch_Checked" Unchecked="IsTrainerBattlesActiveSwitch_Unchecked" IsChecked="True" Foreground="#FF99aab5">
+                <CheckBox.ToolTip>
+                    <ToolTip Background="#2c2f33">
+                        <TextBlock Background="#2c2f33" Foreground="#99aab5"><Run Text="Enables/Disables automatic battling with NPCs"/></TextBlock>
+                    </ToolTip>
+                </CheckBox.ToolTip>
+            </CheckBox>
             <Button
-                Width="96"
+                Width="20"
                 Height="26"
-                Content="Show Options"
+                Content=">"
                 Name="OptionsButton"
-                Visibility="Collapsed"
                 Click="Options_Click"
-                Margin="10,1,2,1"/>
+                Margin="10,1,2,1" Visibility="Collapsed"/>
             <ItemsControl Name="OptionSliders" Visibility="Collapsed">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -355,9 +361,11 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <CheckBox HorizontalAlignment="Left" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="{Binding Name}" IsChecked="{Binding IsEnabled}">
+                        <CheckBox HorizontalAlignment="Left" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="{Binding Name}" IsChecked="{Binding IsEnabled}" Foreground="#FF99aab5">
                             <CheckBox.ToolTip>
-                                <TextBlock Text="{Binding Description}"/>
+                                <ToolTip Background="#2c2f33">
+                                    <TextBlock Background="#2c2f33" Foreground="#99aab5" Text="{Binding Description}"/>
+                                </ToolTip>
                             </CheckBox.ToolTip>
                         </CheckBox>
                     </DataTemplate>
@@ -371,24 +379,22 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Grid ToolTip="{Binding Description}">
+                        <Grid Background="Transparent">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Content="{Binding Name}"/>
-                            <TextBox Grid.Column="1" Text="{Binding Content, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" KeyDown="TextBox_KeyDown" MinWidth="50"/>
+                            <Grid.ToolTip>
+                                <ToolTip Background="#2c2f33">
+                                    <TextBlock Background="#2c2f33" Foreground="#99aab5" Text="{Binding Description}"/>
+                                </ToolTip>
+                            </Grid.ToolTip>
+                            <Label Background="Transparent" Foreground="#FF99aab5" Grid.Column="0" Content="{Binding Name}"/>
+                            <TextBox Background="#2c2f33" Foreground="#FF99aab5" Grid.Column="1" Text="{Binding Content, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" KeyDown="TextBox_KeyDown" MinWidth="50"/>
                         </Grid>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <CheckBox x:Name="IsTrainerBattlesActiveSwitch" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="NPC-Battle: " Checked="IsTrainerBattlesActiveSwitch_Checked" Unchecked="IsTrainerBattlesActiveSwitch_Unchecked" IsChecked="True" Foreground="#FF99aab5">
-                <CheckBox.ToolTip>
-                    <ToolTip Background="#2c2f33">
-                        <TextBlock Background="#2c2f33" Foreground="#99aab5"><Run Text="Enables/Disables to battle with NPC"/></TextBlock>
-                    </ToolTip>
-                </CheckBox.ToolTip>
-            </CheckBox>
         </WrapPanel>
         <Grid Grid.Row="2" Name="Main">
             <Grid.ColumnDefinitions>

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -207,7 +207,7 @@ namespace PROShine
             {
                 if (_sliderOptions.Count == 1 && _textOptions.Count == 0)
                 {
-                    OptionsButton.Content = "Show Options";
+                    OptionsButton.Content = ">";
                     OptionsButton.Visibility = Visibility.Collapsed;
                     OptionSliders.Visibility = Visibility.Collapsed;
                     TextOptions.Visibility = Visibility.Collapsed;
@@ -224,7 +224,7 @@ namespace PROShine
             {
                 if (_textOptions.Count == 1 && _sliderOptions.Count == 0)
                 {
-                    OptionsButton.Content = "Show Options";
+                    OptionsButton.Content = ">";
                     OptionsButton.Visibility = Visibility.Collapsed;
                     OptionSliders.Visibility = Visibility.Collapsed;
                     TextOptions.Visibility = Visibility.Collapsed;
@@ -239,13 +239,13 @@ namespace PROShine
         {
             if (OptionSliders.Visibility == Visibility.Collapsed)
             {
-                OptionsButton.Content = "Hide Options";
+                OptionsButton.Content = "<";
                 OptionSliders.Visibility = Visibility.Visible;
                 TextOptions.Visibility = Visibility.Visible;
             }
             else
             {
-                OptionsButton.Content = "Show Options";
+                OptionsButton.Content = ">";
                 OptionSliders.Visibility = Visibility.Collapsed;
                 TextOptions.Visibility = Visibility.Collapsed;
             }
@@ -482,7 +482,7 @@ namespace PROShine
                     _textOptions.Clear();
                     OptionSliders.Items.Refresh();
                     TextOptions.Items.Refresh();
-                    OptionsButton.Content = "Show Options";
+                    OptionsButton.Content = ">";
                     OptionsButton.Visibility = Visibility.Collapsed;
                     OptionSliders.Visibility = Visibility.Collapsed;
                     TextOptions.Visibility = Visibility.Collapsed;
@@ -523,6 +523,7 @@ namespace PROShine
             lock (Bot)
             {
                 Bot.Stop();
+                Bot.CancelInvokes();
             }
         }
 

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -28,6 +28,7 @@ namespace PROShine.Views
         private Shape[] _npcs;
         private bool _arePlayersDirty;
         private Shape[] _otherPlayers;
+        private Shape _selectedSquare;
 
         private Point _lastDisplayedCell = new Point(-1, -1);
         private Point _playerPosition = new Point();
@@ -58,6 +59,13 @@ namespace PROShine.Views
             IsVisibleChanged += MapView_IsVisibleChanged;
             MouseDown += MapView_MouseDown;
             SizeChanged += MapView_SizeChanged;
+
+            _selectedSquare = new Rectangle
+            {
+                Stroke = Brushes.Red,
+                Fill = Brushes.Transparent,
+                StrokeThickness = 1
+            };
         }
 
         private void MapCanvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -105,13 +113,15 @@ namespace PROShine.Views
 
             if (_lastDisplayedCell.X != ingameX || _lastDisplayedCell.Y != ingameY)
             {
+                Canvas.SetLeft(_selectedSquare, (ingameX + deltaX) * _cellWidth);
+                Canvas.SetTop(_selectedSquare, (ingameY + deltaY) * _cellWidth);
                 lock (_bot)
                 {
                     if (_bot.Game != null && _bot.Game.IsMapLoaded)
-                    {
                         RetrieveCellInfo(ingameX, ingameY);
-                        FloatingTip.IsOpen = true;
-                    }
+                    else
+                        TipText.Text = $"Cell: ({ingameX},{ingameY})";
+                    FloatingTip.IsOpen = true;
                 }
             }
 
@@ -323,6 +333,10 @@ namespace PROShine.Views
                 RefreshPlayer(false);
                 RefreshNpcs();
                 RefreshOtherPlayers();
+
+                _selectedSquare.Width = _cellWidth;
+                _selectedSquare.Height = _cellWidth;
+                MapCanvas.Children.Add(_selectedSquare);
             }
         }
 

--- a/PROShine/Views/TeamView.xaml
+++ b/PROShine/Views/TeamView.xaml
@@ -20,6 +20,7 @@
                 <ListView.ItemContainerStyle>
                     <Style>
                         <Setter Property="ToolTipService.ShowDuration" Value="60000"/>
+                        <Setter Property="ToolTipService.InitialShowDelay" Value="0"/>
                         <Setter Property="Control.ToolTip">
                             <Setter.Value>
                                 <Canvas Height="300" Width="430" Background="#FF1F2225">
@@ -102,12 +103,172 @@
                                             <TextBlock Text="SPDEF:" Canvas.Top="81" Canvas.Left="3" FontSize="15" Foreground="#ffffff"/>
                                             <TextBlock Text="HP:" Canvas.Top="101" Canvas.Left="3" FontSize="15" Foreground="#ffffff"/>
 
-                                            <TextBlock Text="{Binding Stats.Attack}" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
-                                            <TextBlock Text="{Binding Stats.Defence}" Canvas.Top="21" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
-                                            <TextBlock Text="{Binding Stats.Speed}" Canvas.Top="41" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
-                                            <TextBlock Text="{Binding Stats.SpAttack}" Canvas.Top="61" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
-                                            <TextBlock Text="{Binding Stats.SpDefence}" Canvas.Top="81" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
-                                            <TextBlock Text="{Binding Stats.Health}" Canvas.Top="101" Canvas.Right="52" FontSize="15" Foreground="#ffffff"/>
+                                            <TextBlock Text="{Binding Stats.Attack}" Canvas.Right="52" FontSize="15">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="White"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Adamant">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Brave">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Lonely">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Naughty">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Bold">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Calm">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Modest">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Timid">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Stats.Defence}" Canvas.Top="21" Canvas.Right="52" FontSize="15">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="White"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Bold">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Impish">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Lax">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Relaxed">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Gentle">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Hasty">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Lonely">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Mild">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Stats.Speed}" Canvas.Top="41" Canvas.Right="52" FontSize="15">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="White"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Hasty">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Jolly">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Naive">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Timid">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Brave">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Quiet">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Relaxed">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Sassy">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Stats.SpAttack}" Canvas.Top="61" Canvas.Right="52" FontSize="15">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="White"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Mild">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Modest">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Quiet">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Rash">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Adamant">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Careful">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Impish">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Jolly">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Stats.SpDefence}" Canvas.Top="81" Canvas.Right="52" FontSize="15">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="White"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Calm">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Careful">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Gentle">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Sassy">
+                                                                <Setter Property="Foreground" Value="Green"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Lax">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Naive">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Naughty">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Nature.Name}" Value="Rash">
+                                                                <Setter Property="Foreground" Value="Red"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Stats.Health}" Canvas.Top="101" Canvas.Right="52" FontSize="15" Foreground="White"/>
 
                                             <TextBlock Text="{Binding IV.Attack}" Canvas.Right="33" FontSize="15" Foreground="#D48600"/>
                                             <TextBlock Text="{Binding IV.Defence}" Canvas.Top="21" Canvas.Right="33" FontSize="15" Foreground="#D48600"/>

--- a/PROShine/Views/TeamView.xaml
+++ b/PROShine/Views/TeamView.xaml
@@ -23,14 +23,91 @@
                         <Setter Property="ToolTipService.InitialShowDelay" Value="0"/>
                         <Setter Property="Control.ToolTip">
                             <Setter.Value>
-                                <Canvas Height="300" Width="430" Background="#FF1F2225">
+                                <Canvas Height="300" Width="430">
+                                    <Canvas.Style>
+                                        <Style TargetType="Canvas">
+                                            <Setter Property="Background" Value="#FF1F2225"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                    <Setter Property="Background" Value="#e5cf52"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Canvas.Style>
+                                    
                                     <!-- Header -->
-                                    <TextBlock Canvas.Top="5" Canvas.Left="10" Text="{Binding Name}" FontSize="18" FontWeight="ExtraBold" Foreground="#ffffff"/>
-                                    <TextBlock Canvas.Top="8" Canvas.Left="184" Text="{Binding Gender}"  FontSize="15" Foreground="#ffffff"/>
-                                    <TextBlock Canvas.Top="8" Canvas.Left="237" Text="Level:" FontSize="15" Foreground="#ffffff"/>
-                                    <TextBlock Canvas.Top="8" Canvas.Left="279" Text="{Binding Experience.CurrentLevel}" FontSize="15" Foreground="White"/>
-                                    <TextBlock Canvas.Top="8" Canvas.Left="324" Text="Id:" FontSize="15" Foreground="#ffffff"/>
-                                    <TextBlock Canvas.Top="8" Canvas.Left="345" Text="{Binding Id}" FontSize="15" Foreground="White"/>
+                                    <TextBlock Canvas.Top="5" Canvas.Left="10" Text="{Binding Name}" FontSize="18" FontWeight="ExtraBold">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>                                        
+                                    </TextBlock>
+                                    <TextBlock Canvas.Top="8" Canvas.Left="184" Text="{Binding Gender}"  FontSize="15">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Canvas.Top="8" Canvas.Left="237" Text="Level:" FontSize="15">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Canvas.Top="8" Canvas.Left="279" Text="{Binding Experience.CurrentLevel}" FontSize="15">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Canvas.Top="8" Canvas.Left="324" Text="Id:" FontSize="15">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Canvas.Top="8" Canvas.Left="345" Text="{Binding Id}" FontSize="15">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="White"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsShiny}" Value="True">
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
 
                                     <!-- Main -->
                                     <Canvas Canvas.Top="30" Canvas.Left="10" Width="410" Height="260" Background="#2c2f33">


### PR DESCRIPTION
Adds some quality of life fixes.

1. Fixes custom script options layout and converts them to dark mode.
2. Changes "Show Options" and "Hide Options" to just ">" and "<" respectively.
3. Adds a red square to the map view that follows the mouse to easily see what cell you're on.
4. Removes delay when opening Team View information panel.
5. Adds Red and Green colored text to Team View info panel stats according to the nature of the Pokemon.
(e.g. Makes the Attack stat green and the Special Attack stat red for Pokemon with Adamant.)
6. Adds a gold border with black text for shiny team members.